### PR TITLE
The app can now send messages when charging stopped or battery is low

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ captures/
 
 # Intellij
 *.iml
-.idea/workspace.xml
+.idea
 
 # Keystore files
 *.jks

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.0"
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "com.micutu.locatedriver"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,15 @@
             </intent-filter>
         </receiver>
 
+        <receiver
+            android:name=".BroadcastReceivers.BatteryReceiver"
+            android:exported="true">
+            <intent-filter android:priority="998">
+                <action android:name="android.intent.action.ACTION_POWER_DISCONNECTED"/>
+                <action android:name="android.intent.action.BATTERY_LOW"/>
+            </intent-filter>
+        </receiver>
+
         <service android:name=".Services.SmsSenderService" android:exported="false"/>
         <meta-data tools:replace="android:value" android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
     </application>
@@ -41,5 +50,6 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
+    <!--uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/-->
 
 </manifest>

--- a/app/src/main/java/com/micutu/locatedriver/BroadcastReceivers/BatteryReceiver.java
+++ b/app/src/main/java/com/micutu/locatedriver/BroadcastReceivers/BatteryReceiver.java
@@ -1,0 +1,57 @@
+package com.micutu.locatedriver.BroadcastReceivers;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.micutu.locatedriver.R;
+import com.micutu.locatedriver.Services.SmsSenderService;
+import com.micutu.locatedriver.Utilities.Constants;
+import com.micutu.locatedriver.Utilities.Permissions;
+
+public class BatteryReceiver extends BroadcastReceiver {
+    private final static String TAG = BatteryReceiver.class.getSimpleName();
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if(intent == null) {
+            return;
+        }
+        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
+        String targetPhoneNumber = settings.getString(Constants.PHONE_NUMBER_KEY, null);
+        boolean shouldSendChargingStoppedMessages = settings.getBoolean(context.getString(R.string.settings_send_charging_stopped_warnings), false);
+        boolean shouldSendLowBatteryMessages = settings.getBoolean(context.getString(R.string.settings_send_low_battery_warnings), false);
+
+        if(!shouldSendLowBatteryMessages && !shouldSendChargingStoppedMessages) {
+            return;
+        }
+        if(targetPhoneNumber == null) {
+            Log.w(TAG, "Cannot send battery warning, no phone number provided");
+            return;
+        }
+        if (!Permissions.haveSendSMSAndLocationPermission(context)) {
+            try {
+                Permissions.setPermissionNotification(context);
+            } catch (Exception e) {
+                Toast.makeText(context, R.string.send_sms_and_location_permission, Toast.LENGTH_SHORT).show();
+            }
+            return;
+        }
+        String smsType = null;
+        if(Intent.ACTION_POWER_DISCONNECTED.equals(intent.getAction()) && shouldSendChargingStoppedMessages) {
+            smsType = SmsSenderService.SMS_TYPE_SEND_CHARGING_STOPPED_WARNING;
+        } else if(Intent.ACTION_BATTERY_LOW.equals(intent.getAction()) && shouldSendLowBatteryMessages) {
+            smsType = SmsSenderService.SMS_TYPE_SEND_LOW_BATTERY_WARNING;
+        }
+        if(smsType != null) {
+            Intent newIntent = new Intent(context, SmsSenderService.class);
+            newIntent.putExtra(SmsSenderService.PHONE_NUMBER_KEY, targetPhoneNumber);
+            newIntent.putExtra(SmsSenderService.SMS_TYPE_KEY, smsType);
+            context.startService(newIntent);
+        }
+    }
+}

--- a/app/src/main/java/com/micutu/locatedriver/BroadcastReceivers/SmsReceiver.java
+++ b/app/src/main/java/com/micutu/locatedriver/BroadcastReceivers/SmsReceiver.java
@@ -15,6 +15,9 @@ import com.micutu.locatedriver.Utilities.Permissions;
 
 import java.util.ArrayList;
 
+import static com.micutu.locatedriver.Services.SmsSenderService.SMS_TYPE_KEY;
+import static com.micutu.locatedriver.Services.SmsSenderService.SMS_TYPE_SEND_LOCATION;
+
 public class SmsReceiver extends BroadcastReceiver {
     private final static String TAG = SmsReceiver.class.getSimpleName();
 
@@ -54,7 +57,8 @@ public class SmsReceiver extends BroadcastReceiver {
         }
 
         Intent newIntent = new Intent(context, SmsSenderService.class);
-        newIntent.putExtra("phoneNumber", list.get(0).getOriginatingAddress());
+        newIntent.putExtra(SMS_TYPE_KEY, SMS_TYPE_SEND_LOCATION);
+        newIntent.putExtra(SmsSenderService.PHONE_NUMBER_KEY, list.get(0).getOriginatingAddress());
         context.startService(newIntent);
     }
 

--- a/app/src/main/java/com/micutu/locatedriver/Utilities/Constants.java
+++ b/app/src/main/java/com/micutu/locatedriver/Utilities/Constants.java
@@ -1,0 +1,8 @@
+package com.micutu.locatedriver.Utilities;
+
+public class Constants {
+
+    // Share preferences
+    public static String PHONE_NUMBER_KEY = "phone_number";
+    public static String LAST_CHARGING_STOPPED_WARNING_SENT_AT_KEY = "last_charging_stopped_warning_sent_at";
+}

--- a/app/src/main/java/com/micutu/locatedriver/Utilities/Permissions.java
+++ b/app/src/main/java/com/micutu/locatedriver/Utilities/Permissions.java
@@ -69,7 +69,7 @@ public class Permissions {
         PendingIntent resultPendingIntent = PendingIntent.getActivity(context, 0, resultIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
         NotificationCompat.Builder notificaitonBuilder = new NotificationCompat.Builder(context)
-                .setSmallIcon(R.drawable.notification_icon)
+                .setSmallIcon(R.mipmap.ic_launcher)
                 .setLargeIcon(BitmapFactory.decodeResource(context.getResources(), R.mipmap.ic_launcher))
                 .setContentTitle(context.getString(R.string.notification_title))
                 .setContentText(context.getString(R.string.notification_content))

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -53,6 +53,17 @@
                         android:id="@+id/keyword"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:text="@string/phone_number" />
+
+                    <EditText
+                        android:id="@+id/phone_number_input"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content" />
                 </LinearLayout>
 
                 <RelativeLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,10 +1,25 @@
 <resources>
+    <!-- Settings -->
+    <string name="settings_enable_in_ups_mode">settings_enable_in_ups_mode</string>
+    <string name="settings_send_low_battery_warnings">settings_send_low_battery_warnings</string>
+    <string name="settings_send_charging_stopped_warnings">settings_send_charging_stopped_warnings</string>
+
+    <string name="send_low_battery_warnings">Send low battery warning</string>
+    <string name="send_low_battery_warnings_summary">Send an SMS to the given number when battery is low.</string>
+    <string name="send_charging_stopped_warnings">Send charging stopped warning</string>
+    <string name="send_charging_stopped_warnings_summary">Send an SMS to the given number when charging stopped.</string>
+
     <string name="app_name">Locate driver</string>
     <string name="current_state_card_title">Setup</string>
     <string name="settings_card_title">Settings</string>
     <string name="about_card_title">About</string>
     <string name="destination">Pick destination</string>
     <string name="keyword">SMS Keyword:</string>
+    <string name="phone_number">Phone number for battery warnings</string>
+    <string name="charging_stopped">Charging stopped</string>
+    <string name="charging_stopped_x_remaining">Charging stopped: %1$d %% remaining</string>
+    <string name="low_battery">Low battery</string>
+    <string name="low_battery_x_remaining">Low battery: %1$d %% remaining</string>
     <string name="destination_error">Error choosing destination :(</string>
     <string name="stop">Stop</string>
     <string name="start">Start</string>
@@ -14,6 +29,8 @@
     <string name="error_permission">Application needs all the permissions to be granted because without them it can\'t function correctly.</string>
     <string name="sound_title">Sound (not yet)</string>
     <string name="sound_summary">Notification when keyword was detected.</string>
+    <string name="ultra_power_saving_mode">Ultra power saving mode</string>
+    <string name="ultra_power_saving_mode_summary">Enable the app to run in ultra power saving mode (may not work on all devices)</string>
     <string name="detected_message_title">First message</string>
     <string name="detected_message_summary">Acknowledge that keyword was detected and send mobile data and GPS status.</string>
     <string name="gps_message_title">Second message</string>

--- a/app/src/main/res/xml/settings_preferences.xml
+++ b/app/src/main/res/xml/settings_preferences.xml
@@ -35,10 +35,31 @@
         android:defaultValue="true"/>
 
     <CheckBoxPreference
+        android:key="@string/settings_send_low_battery_warnings"
+        android:title="@string/send_low_battery_warnings"
+        android:summary="@string/send_low_battery_warnings_summary"
+        android:defaultValue="false"/>
+
+    <CheckBoxPreference
+        android:key="@string/settings_send_charging_stopped_warnings"
+        android:title="@string/send_charging_stopped_warnings"
+        android:summary="@string/send_charging_stopped_warnings_summary"
+        android:defaultValue="false"/>
+
+    <CheckBoxPreference
         android:enabled="false"
         android:key="settings_sound"
         android:title="@string/sound_title"
         android:summary="@string/sound_summary"
         android:defaultValue="false"/>
+
+    <!-- NOTE: If uncommenting this, also uncomment REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
+    permission in manifest. It is not used by default as Google Play restricts it -->
+    <!--CheckBoxPreference
+        android:enabled="true"
+        android:key="@string/settings_enable_in_ups_mode"
+        android:title="@string/ultra_power_saving_mode"
+        android:summary="@string/ultra_power_saving_mode_summary"
+        android:defaultValue="false"/-->
 
 </PreferenceScreen>

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:3.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,6 +16,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 


### PR DESCRIPTION
Thank you for your work Șandor, I'm planning to revive my old phone as a GPS tracker and this app seems to be a great fit - no expensive data plans needed, controlled via SMS. I just missed the option to learn when my phone's battery needs to be recharged. To extend overall battery life, I'll also have it plugged to a power brick, that's why I also added a notification SMS when the brick runs out of juice (and device stops charging). For this second case I'm only sending an SMS at most once per 6 hours to avoid unwanted SMS costs when charging the phone normally.
The new functionality is opt-in, it can be turned on and off on the preferences screen. I share it for the case that someone else would find it useful.